### PR TITLE
adding R^2 values and testing pull request

### DIFF
--- a/cord/data/Rsquares.txt
+++ b/cord/data/Rsquares.txt
@@ -1,0 +1,12 @@
+Timestep       Daily        Weekly       Monthly      Water Year   
+DEL_HRO_pump   0.227        0.269        0.338        0.841        
+DEL_TRP_pump   0.342        0.402        0.491        0.797        
+None           0.429        0.487        0.601        0.893        
+SHA_storage    0.813        0.813        0.814        0.776        
+SHA_out        0.615        0.697        0.795        0.907        
+FOL_storage    0.744        0.744        0.747        0.732        
+FOL_out        0.820        0.868        0.915        0.989        
+ORO_storage    0.881        0.880        0.880        0.896        
+ORO_out        0.633        0.714        0.845        0.968        
+DEL_in         0.951        0.961        0.982        0.998        
+DEL_out        0.949        0.960        0.983        0.996        


### PR DESCRIPTION
Testing pull request to see if this will work. The edits made previously in the last two commits speed up the simulation time. The code runs in 1.9 seconds, plus .7 seconds if we calculate R^2s, giving total run time of 2.6 seconds without plotting. This was done by interpolating tocs and pumping outside the functions, so that a list for the values in each year can be made. These lists are indexed in the functions. This leads to significantly less time used by np.interp(). 